### PR TITLE
fix minor bugs, add close handler

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -69,6 +69,8 @@ type Buffer struct {
 	hasActiveReader bool
 	flowID          uuid.UUID
 	logger          *zap.SugaredLogger
+
+	bytesWritten int64
 }
 
 // NewBuffer constructs a new buffer with the given size and logger. See Buffer for more information.
@@ -204,6 +206,7 @@ func (b *Buffer) Write(p []byte) (n int, err error) {
 	}
 
 	b.buffer = append(b.buffer, p[:availableCapacity]...)
+	b.bytesWritten += availableCapacity
 
 	b.cond.Broadcast()
 


### PR DESCRIPTION
This change fixes a few minor bugs, they are:
- Properly wait for WebSocket goroutine to close when a client is closed, this was preventing a test from passing in managed-service due to the stray goroutine.
- Use the correct timeout for keep alive timeouts. This was causing clients initialized without a timeout to constantly timeout even though heartbeats were working, due to default timeout not being used correctly.

This change also adds a close handler to the server. This allows the server to get statistics about the duration and bytes transferred of a connection. This can then be exposed as metrics from the caller.